### PR TITLE
#153241414 Format news sources view

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -11,7 +11,7 @@ class Sources extends Component {
     const sources = this.props.sources;
     return (
       <div className="body">
-        <h1>News Sources</h1>
+        <h1 className='news-sources-heading'>News Sources</h1>
         <DashboardItems sources={sources}/>
     </div>
     );

--- a/src/components/dashboard/DashboardItems.js
+++ b/src/components/dashboard/DashboardItems.js
@@ -4,11 +4,16 @@ import { PropTypes } from 'prop-types';
 const DashboardItems = ({sources}) => {
   console.log(sources.sources);
   return (
-     <div>
+     <div className='news-sources-list-wrapper'>
         {sources.sources.map(source =>
-          <div className='news-list' key={ source.id }>
-            <li>{ source.name }</li>
-            {source.description}
+          <div className='news-sources-list' key={ source.id }>
+            <div><img className='news-source-logo' 
+            src={'https://icons.better-idea.org/icon?url='+source.url+'&amp;size=70..120..200'}></img></div>
+            <div className='news-sources-text'><h2>{ source.name }</h2>
+            <p>{ source.description }</p>
+            <h3><p>Category: { source.category }</p></h3>
+            <a href={ source.url } target='_blank'>{ source.url }</a>
+            </div>
             </div>
         )}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -64,6 +64,10 @@ menu {
 	color: #000000;
 }
 
+.news-sources-heading {
+	margin-left: 20px;
+}
+
 .news-sources {
 	width: 119px;
 	height: 29px;
@@ -80,7 +84,22 @@ menu {
 	width: 1024px;
 	height: 686px;
 }
-
-.news-list {
+.news-sources-list-wrapper {
+	text-align: center;
+}
+.news-sources-list {
+	float: left;
 	display: inline-block;
+	width: 27%;
+	height: 350px;
+	border: 3px solid #2a9d2b;
+	margin: 10px 40px 10px 10px;
+}
+.news-source-logo {
+	width: 80px;
+	height: 80px;
+}
+.news-sources-text {
+	flex: 1;
+	text-align: center;
 }


### PR DESCRIPTION
#### What does this PR do?
Currently the news sources on the news source page are presented as a
list which is not viewer friendly.

This ensures that the news sources presented in block form on the
news sources view.

#### Description of Task to be completed?
add CSS code that will format the view that will make each each news source appear as a block with the information of the news source within the block. Also the content in each block will need to be arranged and individual properties called from the news source object to get information on the news source such as `logo`, `name`, `description` `category` and `url` of the news source.

#### How should this be manually tested?
run the app and navigate to the `News Sources` tab to see the way the news sources are being displayed.

#### What are the relevant pivotal tracker stories?
[#153241414](https://www.pivotaltracker.com/story/show/153241414)